### PR TITLE
+ Per-user configuration for GitHub <=> Git integration and key-based auth

### DIFF
--- a/.ssh/config
+++ b/.ssh/config
@@ -4,10 +4,45 @@ Host *
   ServerAliveCountMax 2
   PreferredAuthentications publickey,password,keyboard-interactive
   GSSAPIAuthentication no
+  IdentitiesOnly yes
+#  IdentityFile ~/.ssh/default-private-key
 
+#__________________________________________________________________
 
-#   Host github.com
-#     Hostname github.com
-#     User git
-#     IdentityFile ~/.ssh/rsa......
+##
+##   Example of per-username github config
+##   Actual user name at SSH proto level MUST be git
+##   Leftmost part of hostname specifies your name in Github
+##      and that's a github-specific feature which may allow
+##      your git client to sign in to different Github accounts 
+##      with same key, should you need it that way.
+##   All you'd need to do is clone from acme.github.com from
+##      the very beginning or set up git remote to acme.github.com
+##
+##   Host acme.github.com
+##     Hostname github.com
+##     User git
+##     IdentityFile ~/.ssh/rsa......
+
+Host skv.github.com
+  Hostname github.com
+  User git
+  #  IdentityFile ~/.ssh/secondary-private-github-key
+
+Host ashtarsheran.github.com
+  Hostname github.com
+  User git
+  #IdentityFile ~/.ssh/primary-private-github-key
+  #IdentityFile <or maybe even same SSH key here>
+
+Host acme.github.com
+  Hostname github.com
+  User git
+#  IdentityFile acme-key-here
+
+Host whatever.github.com
+  Hostname github.com
+  User git
+#  IdentityFile whatever-key-here
+
 


### PR DESCRIPTION
Adds to ~/.ssh/config some per-user configuration
of GitHub subdomains + respective keys so that 
one could use Git + repos associated with different 
GitHub accounts without much of an effort