### PR TITLE
SSH authorized_keys: use `command` to set up home env

### DIFF
--- a/.ssh/authorized_keys
+++ b/.ssh/authorized_keys
@@ -1,0 +1,5 @@
+# Here I (ab)use the `command` part of options field in the authorized_keys file.
+# For more info see https://man.freebsd.org/cgi/man.cgi?query=sshd&sektion=8#AUTHORIZED_KEYS_FILE_FORMAT
+
+command="HOME_ORIG=$HOME;HOME=/home/www/devcontrol/dev-kshpolvind-files; cd $HOME; if [ \( -n \"$SSH_ORIGINAL_COMMAND\" \) -a \( \"$SSH_ORIGINAL_COMMAND\" != \"$SHELL\" \) ]; then eval \"$SSH_ORIGINAL_COMMAND\"; else exec \"$SHELL\"; fi" ssh-rsa AAAAB3Nza... 1F5P+dNCP just@example-key
+


### PR DESCRIPTION
(Ab)Uses the `command` in authorized_keys to setup home dir and env in general